### PR TITLE
Security Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "0.12"
+  - "10.23.0"
   - "stable"
 
 sudo: false

--- a/lib/deps_changed_stream.js
+++ b/lib/deps_changed_stream.js
@@ -161,7 +161,7 @@ function debugRelatedFiles(isEnabled, dependentVinylFile) {
         .observe()
         .each(function(dependingVinylFiles) {
           console.log('Related files %j (from "%s")',
-                      lodash.pluck(dependingVinylFiles, 'path'),
+                      lodash.map(dependingVinylFiles, 'path'),
                       dependentVinylFile.path);
         });
     }

--- a/package.json
+++ b/package.json
@@ -26,19 +26,19 @@
     "url": "https://github.com/mixi-inc/gulp-dependencies-changed/issues"
   },
   "engines": {
-    "node" : ">=0.12"
+    "node": ">=10.23.0"
   },
   "homepage": "https://github.com/mixi-inc/gulp-dependencies-changed",
   "devDependencies": {
-    "chai": "^3.2.0",
-    "chai-as-promised": "^5.1.0",
-    "es6-promise": "^3.0.2",
-    "mocha": "^2.2.5",
+    "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
+    "es6-promise": "^4.2.8",
+    "mocha": "^8.2.1",
     "vinyl": "^0.5.1"
   },
   "dependencies": {
     "highland": "^2.5.1",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.20",
     "vinyl-file": "^1.2.1"
   }
 }

--- a/tests/test_deps_changed_stream.js
+++ b/tests/test_deps_changed_stream.js
@@ -287,7 +287,7 @@ describe('collectDependings', function() {
       .flatMap(collectDependings(matcher, relativeResolver));
 
     return waitUntilStreamEnd(stream, function(dependingVinylFiles) {
-      var dependingFilePaths = lodash.pluck(dependingVinylFiles, 'path');
+      var dependingFilePaths = lodash.map(dependingVinylFiles, 'path');
 
       assert.sameMembers(dependingFilePaths, [
         getFixturePath('parent'),
@@ -301,7 +301,7 @@ describe('collectDependings', function() {
       .flatMap(collectDependings(matcher, relativeResolver));
 
     return waitUntilStreamEnd(stream, function(dependingVinylFiles) {
-      var dependingFilePaths = lodash.pluck(dependingVinylFiles, 'path');
+      var dependingFilePaths = lodash.map(dependingVinylFiles, 'path');
 
       assert.sameMembers(dependingFilePaths, [
         getFixturePath('parent'),
@@ -350,7 +350,7 @@ function createFixtureVinylFileStream(fileName) {
 function createVinylFile(opts) {
   return new VinylFile({
     path: opts.path || 'path/to/file',
-    contents: new Buffer(opts.contentString || 'CONTENTS'),
+    contents: Buffer.from(opts.contentString || 'CONTENTS'),
     stat: { mtime: opts.mtime || new Date('2000/01/01') },
   });
 }


### PR DESCRIPTION
```
~/gulp-dependencies-changed ❯❯❯ npm test

> gulp-dependencies-changed@1.0.2 test /home/shinji.otsuka/gulp-dependencies-changed
> mocha tests



  gulp-dependecies-changed
    ✓ should export a stream factory function
    ✓ should export a compareByMtime function
    ✓ should export a relativeResolver function

  createDependenciesChangedStream
    ✓ should return a stream
    ✓ should pass when the target file is not found
    ✓ should pass when the dependent is newer than the target file
    ✓ should pass when the dependings is newer than the target file
    ✓ should drop when the dependent and the dependings is older than the target file

  compareByMtime
    ✓ should return true when the first vinyl file is newer than the other
    ✓ should return false when the first vinyl file is older than the other
    ✓ should return false when the both vinyl files have same mtime

  collectDependings
    ✓ should return depending vinyl-files
    ✓ should return depending vinyl-files recursively


  13 passing (49ms)

~/gulp-dependencies-changed ❯❯❯ npm audit

                       === npm audit security report ===

found 0 vulnerabilities
 in 124 scanned packages
```